### PR TITLE
컴포넌트 다중 렌더링 버그 수정

### DIFF
--- a/src/components/auth/Input.tsx
+++ b/src/components/auth/Input.tsx
@@ -1,4 +1,14 @@
-import { useValid } from '@/hooks/auth/useValid';
+import {
+  bnoNumberInput,
+  businessNameInput,
+  emailInput,
+  passwordConfirmInput,
+  passwordInput,
+  passwordSignUpInput,
+  storeBusineesNameInput,
+  storeEmailInput,
+} from '@/data/input-props';
+import { useErrorMessage } from '@/hooks/auth/useErrorMessage';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import styles from './styles/Auth.module.css';
@@ -19,69 +29,8 @@ interface InputType {
 
 const Input = ({ value, onChangeHandler }: InputProps) => {
   const path = useRouter().pathname;
-  const { passwordErrorMessage } = useValid(value);
-
-  const emailInput = {
-    id: 1,
-    name: 'email',
-    type: 'text',
-    label: '사용하실 이메일과 비밀번호를 입력해 주세요.',
-    placeholder: '이메일',
-  };
-
-  const passwordInput = {
-    id: 2,
-    name: 'password',
-    type: 'password',
-    placeholder: '비밀번호',
-  };
-
-  const passwordSignUpInput = {
-    id: 3,
-    name: 'password',
-    type: 'password',
-    placeholder: '비밀번호 (대소문자/특수문자 포함 8~16자리 영문)',
-  };
-
-  const passwordConfirmInput = {
-    id: 4,
-    name: 'passwordConfirm',
-    type: 'password',
-    placeholder: '비밀번호 확인',
-  };
-
-  const businessNameInput = {
-    id: 5,
-    name: 'businessName',
-    label: '상호명을 입력해 주세요.',
-    type: 'text',
-    placeholder: '상호명',
-  };
-
-  const storeEmailInput = {
-    id: 6,
-    name: 'storeEmail',
-    type: 'text',
-    label: '이메일',
-    disabled: true,
-  };
-
-  const bnoNumberInput = {
-    id: 7,
-    name: 'bnoNumber',
-    type: 'text',
-    label: '사업자등록번호',
-    disabled: true,
-  };
-
-  const storeBusineesNameInput = {
-    id: 8,
-    name: 'storeName',
-    type: 'text',
-    label: '상호명',
-    placeholder: '가게 이름',
-    disabled: true,
-  };
+  // const { passwordErrorMessage } = useValid(value);
+  const { isPasswordValid, passwordValidationMessage } = useErrorMessage(value);
 
   const inputOptions: Record<string, InputType[]> = {
     '/auth/login': [emailInput, passwordInput],

--- a/src/components/auth/Input.tsx
+++ b/src/components/auth/Input.tsx
@@ -46,8 +46,7 @@ const Input = ({ value, onChangeHandler }: InputProps) => {
     <>
       {inputs.map((input: InputType) => {
         const key = input.name;
-        const isPasswordConfirm = input.name === 'passwordConfirm';
-        const isSuccess = passwordErrorMessage === '비밀번호가 일치합니다.' && isPasswordConfirm;
+        const isPasswordConfirm = input.name === 'passwordConfirm' && path === '/auth/signup';
 
         if (input) {
           return (
@@ -57,7 +56,7 @@ const Input = ({ value, onChangeHandler }: InputProps) => {
               <input
                 id={input.name}
                 className={clsx(styles.input, {
-                  [styles.inputError]: !isSuccess && isPasswordConfirm && passwordErrorMessage !== '',
+                  [styles.inputError]: isPasswordConfirm && !isPasswordValid,
                 })}
                 name={input.name}
                 value={value[key]}
@@ -67,9 +66,8 @@ const Input = ({ value, onChangeHandler }: InputProps) => {
                 disabled={input.disabled}
                 required
               />
-              {/* 로그인 & 회원가입 둘 다 적용 */}
-              {input.name === 'passwordConfirm' && (
-                <span className={isSuccess ? styles.match : styles.error}>{passwordErrorMessage || ''}</span>
+              {isPasswordConfirm && (
+                <span className={isPasswordValid ? styles.match : styles.error}>{passwordValidationMessage}</span>
               )}
             </div>
           );

--- a/src/data/input-props.ts
+++ b/src/data/input-props.ts
@@ -1,0 +1,61 @@
+export const emailInput = {
+  id: 1,
+  name: 'email',
+  type: 'text',
+  label: '사용하실 이메일과 비밀번호를 입력해 주세요.',
+  placeholder: '이메일',
+};
+
+export const passwordInput = {
+  id: 2,
+  name: 'password',
+  type: 'password',
+  placeholder: '비밀번호',
+};
+
+export const passwordSignUpInput = {
+  id: 3,
+  name: 'password',
+  type: 'password',
+  placeholder: '비밀번호 (대소문자/특수문자 포함 8~16자리 영문)',
+};
+
+export const passwordConfirmInput = {
+  id: 4,
+  name: 'passwordConfirm',
+  type: 'password',
+  placeholder: '비밀번호 확인',
+};
+
+export const businessNameInput = {
+  id: 5,
+  name: 'businessName',
+  label: '상호명을 입력해 주세요.',
+  type: 'text',
+  placeholder: '상호명',
+};
+
+export const storeEmailInput = {
+  id: 6,
+  name: 'storeEmail',
+  type: 'text',
+  label: '이메일',
+  disabled: true,
+};
+
+export const bnoNumberInput = {
+  id: 7,
+  name: 'bnoNumber',
+  type: 'text',
+  label: '사업자등록번호',
+  disabled: true,
+};
+
+export const storeBusineesNameInput = {
+  id: 8,
+  name: 'storeName',
+  type: 'text',
+  label: '상호명',
+  placeholder: '가게 이름',
+  disabled: true,
+};

--- a/src/hooks/auth/useErrorMessage.ts
+++ b/src/hooks/auth/useErrorMessage.ts
@@ -1,0 +1,19 @@
+export const useErrorMessage = (value: Record<string, string>) => {
+  const { password, passwordConfirm } = value;
+
+  /// 비밀번호와 비밀번호 확인이 모두 입력된 경우에만 비밀번호 일치 여부를 검사합니다.
+  const isPasswordMatch = password && passwordConfirm ? password === passwordConfirm : true;
+
+  // 비밀번호 유효성 메시지는 비밀번호 확인 필드에 값이 있을 때만 설정합니다.
+  const passwordValidationMessage = passwordConfirm
+    ? isPasswordMatch
+      ? '비밀번호가 일치합니다.'
+      : '비밀번호가 일치하지 않습니다.'
+    : '';
+
+  return {
+    isPasswordMatch,
+    passwordValidationMessage,
+    isPasswordValid: passwordConfirm ? isPasswordMatch : true,
+  };
+};

--- a/src/hooks/auth/useValid.ts
+++ b/src/hooks/auth/useValid.ts
@@ -7,8 +7,6 @@ export const useValid = (value: Record<string, string>) => {
   const path = useRouter().pathname;
   const { email, password, passwordConfirm, businessNumber } = value;
   const [isValid, setIsValid] = useState(false);
-  const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
-  const [emailErrorMessage, setEmailErrorMessage] = useState('');
   const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
   const businessNumberRegex = /^\d{10}$/;
 
@@ -18,33 +16,16 @@ export const useValid = (value: Record<string, string>) => {
       const areFieldsFilled =
         email.trim() !== '' && password.trim() !== '' && passwordConfirm.trim() !== '' && businessNumber.trim() !== '';
 
-      // 이메일 에러 메세지 처리
-      setEmailErrorMessage(email.trim() !== '' && !isEmailValid ? '올바른 이메일 형식이 아닙니다.' : '');
-
-      /**
-       * 비밀번호 에러 메세지 처리
-       * 비밀번호가 비어 있지 않을 때만 에러 메시지를 설정합니다.
-       */
-      if (password.trim() !== '' && passwordConfirm.trim() !== '') {
-        setPasswordErrorMessage(!isPasswordMatch ? '비밀번호가 일치하지 않습니다.' : '비밀번호가 일치합니다.');
-      } else {
-        setPasswordErrorMessage(''); // 비밀번호나 비밀번호 확인 값이 변경되었을 때 초기화
-      }
-
-      // 모든 필드가 유효한지 최종 검사하여 isValid 업데이트
       setIsValid(isEmailValid && isPasswordMatch && areFieldsFilled);
     } else {
       const areFieldsFilled = email.trim() !== '' && password.trim() !== '';
 
       setIsValid(isEmailValid && areFieldsFilled);
-      setEmailErrorMessage(email.trim() !== '' && !isEmailValid ? '올바른 이메일 형식이 아닙니다.' : '');
     }
   }, [businessNumber, email, isEmailValid, password, passwordConfirm, path]);
 
   const isBusinessNumberValid =
-    value.businessNumber.length === MAX_BUSINESS_NUM_LENGTH &&
-    businessNumberRegex.test(value.businessNumber) &&
-    isValid;
+    businessNumber?.length === MAX_BUSINESS_NUM_LENGTH && businessNumberRegex.test(businessNumber) && isValid;
 
-  return { isValid, emailErrorMessage, passwordErrorMessage, isBusinessNumberValid };
+  return { isValid, isBusinessNumberValid };
 };

--- a/src/server/api/supabase/auth.ts
+++ b/src/server/api/supabase/auth.ts
@@ -38,7 +38,7 @@ export const loginHandler = async (values: values) => {
     password,
   });
   if (error && error.status === 400) {
-    alert('비밀번호가 일치하지 않습니다.');
+    alert('이메일 또는 비밀번호가 일치하지 않습니다.');
     throw error;
   }
   return data;


### PR DESCRIPTION
admin/store, auth/login, auth/signup 총 3개의 페이지에서 Input 컴포넌트를 사용 중인데 Input 컴포넌트 내부에서 useValid라는 input의 모든 value를 품은 유효성 검사 커스텀 훅을 호출 중이었다. 그래서 "admin/store" 페이지 진입 시 Input 컴포넌트가 렌더링 되면서 동시에  `const { passwordErrorMessage } = useValid(value);`useValid도 호출됐다.

- 받아온 값은 패스워드 에러 메세지이지만 커스텀 훅 안에는 useEffect가 있어서 검사해주는 email, password들이 nullish 하다고 뜬 것.
- admin/store 페이지에서는 password, email을 초기값으로 넘겨주진 않는다.
