### PR TITLE
♻️  이벤트 버블링 활용하여 onClick 이벤트 처리

### DIFF
--- a/src/components/sales/calendar/Calendar.tsx
+++ b/src/components/sales/calendar/Calendar.tsx
@@ -1,7 +1,8 @@
+import { useDataHandler } from '@/hooks/service/sales/useDataHandler';
 import { CalendarType } from '@/types/calendar';
 import clsx from 'clsx';
 import React from 'react';
-import { BIG_MODE, MINI_MODE } from './calendarType/calendarType';
+import { BIG_MODE, MINI_MODE, STATUS_PAGE } from './calendarType/calendarType';
 import Cell from './cell/Cell';
 import Days from './days/Days';
 import Header from './header/Header';
@@ -16,6 +17,7 @@ import styles from './styles/calendar.module.css';
  * @returns
  */
 const Calendar = ({ children, mode, page }: CalendarType) => {
+  const { clickShowDataOfDateHandler } = useDataHandler();
   return (
     <div
       className={clsx({
@@ -38,7 +40,13 @@ const Calendar = ({ children, mode, page }: CalendarType) => {
         })}
       >
         <Days mode={mode} />
-        <Cell mode={mode} page={page} />
+        <Cell
+          mode={mode}
+          page={page}
+          {...(page === STATUS_PAGE && {
+            clickShowDataOfDateHandler: clickShowDataOfDateHandler,
+          })}
+        />
       </div>
     </div>
   );

--- a/src/components/sales/calendar/cell/Cell.tsx
+++ b/src/components/sales/calendar/cell/Cell.tsx
@@ -1,4 +1,3 @@
-import { useDataHandler } from '@/hooks/service/sales/useDataHandler';
 import { getMonthSales } from '@/server/api/supabase/sales';
 import { groupByKey } from '@/shared/helper';
 import useCalendarState from '@/shared/store/sales/salesCalendar';
@@ -17,11 +16,11 @@ import { formatToCalendarData, sortMinMaxData } from '../../calendarUtility/form
 
 import useFilterButton from '@/hooks/service/order-check-list/useFilterButton';
 import { CalendarCellType } from '@/types/calendar';
-import { BIG_MODE, CALENDAR_PAGE, STATUS_PAGE } from '../calendarType/calendarType';
+import { BIG_MODE, CALENDAR_PAGE } from '../calendarType/calendarType';
 import CellItem from '../cellItem/CellItem';
 import styles from './styles/cell.module.css';
 
-const Cell = ({ mode, page }: CalendarCellType) => {
+const Cell = ({ mode, page, clickShowDataOfDateHandler }: CalendarCellType) => {
   /**
    * 캘린더에 사용되는 state입니다 건들지 마십쇼
    */
@@ -30,14 +29,13 @@ const Cell = ({ mode, page }: CalendarCellType) => {
   const startDay = currentDate.startOf('month').startOf('week');
   // monthStart가 속한 마지막 주
   const endDay = currentDate.endOf('month').endOf('week');
-
   /**
    * Sales Page에서 사용하는 state
    */
   const storeId = useAuthState(state => state.storeId);
   const holidays = useHolidayState(state => state.holidays);
   const calendarBindingData = useSalesDataState(state => state.calendarBindingData);
-  const { clickShowDataOfDateHandler } = useDataHandler();
+  // const { clickShowDataOfDateHandler } = useDataHandler();
   const holiday = holidays[currentDate.format('YYYY')];
   /**
    * 다른 페이지에서 호출 되는 공간 입니다. 아래에서 hook으로 써주면 아리가또우
@@ -88,7 +86,6 @@ const Cell = ({ mode, page }: CalendarCellType) => {
           // ... spreadOperator
           // 아래 조건부 함수는 Sales page에서 사용하는 props 입니다.
           {...(page === CALENDAR_PAGE && { getMinMaxSalesType: getMinMaxSalesType })}
-          {...(page === STATUS_PAGE && { clickShowDataOfDateHandler: clickShowDataOfDateHandler })}
           holiday={holidayDate}
           /** 페이지가 주문내역 확인이면 아래와 같이 하면 됩니다.
            *{...((page===ORDER && {clickHandler: clickHandler}))}
@@ -106,7 +103,11 @@ const Cell = ({ mode, page }: CalendarCellType) => {
     );
     days = [];
   }
-  return <div className={styles.calendarBody}>{row}</div>;
+  return (
+    <div className={styles.calendarBody} onClick={clickShowDataOfDateHandler}>
+      {row}
+    </div>
+  );
 };
 
 export default Cell;

--- a/src/components/sales/calendar/cellItem/CellItem.tsx
+++ b/src/components/sales/calendar/cellItem/CellItem.tsx
@@ -16,6 +16,7 @@ import SalesModal from '../../modal/SalesModal';
 
 import { CellItemProps } from '@/types/calendar';
 import clsx from 'clsx';
+import dayjs from 'dayjs';
 import { BIG_MODE, CALENDAR_PAGE, MINI_MODE, STATUS_PAGE } from '../calendarType/calendarType';
 import styles from './styles/cellItem.module.css';
 
@@ -25,7 +26,6 @@ const CellItem: Cell = ({
   day,
   salesData,
   getMinMaxSalesType,
-  clickShowDataOfDateHandler,
   holiday,
   mode,
   page,
@@ -37,7 +37,7 @@ const CellItem: Cell = ({
   const SALES_HAVE = 'HAVE';
   const HOLIDAY = 'HOLIDAY';
   const currentDate = useCalendarState(staet => staet.currentDate);
-  const { selectedDate, today } = useDayState();
+  const selectedDate = useDayState(state => state.selectedDate);
 
   const { MagicModal } = useModal();
 
@@ -106,7 +106,7 @@ const CellItem: Cell = ({
       },
     },
   });
-
+  console.log(dayjs(day).format('YY MM DD'));
   const formatDate = day.format('YY MM D').substring(6);
   return (
     <>
@@ -123,9 +123,6 @@ const CellItem: Cell = ({
 
             // [styles.페이지가 주문내역이면 사용하는 style] : PAGE === ORDER_PAGE
           })}
-          {...(((page === STATUS_PAGE && day.isSame(today, 'D')) || day.isBefore(today, 'D')) && {
-            onClick: clickShowDataOfDateHandler?.(day),
-          })}
           /** 페이지가 주문내역 확인이면 아래와 같이 하면 됩니다.
            *{...((page===ORDER && {onClick: clickHandler}))}
            */
@@ -138,6 +135,7 @@ const CellItem: Cell = ({
               dayType: getStatusDayType(day),
               seletedDayType: day.isSame(selectedDate, 'day') ? SELECTED_DAY : null,
             })}
+            data-dayjs={day}
           >
             {formatDate}
           </span>

--- a/src/hooks/service/sales/useDataHandler.ts
+++ b/src/hooks/service/sales/useDataHandler.ts
@@ -9,7 +9,8 @@ import { setIsShow } from '@/shared/store/sales/salesToggle';
 import useAuthState from '@/shared/store/session';
 import { DateFormatType, EnOrderType, FormatType } from '@/types/sales';
 import { Tables } from '@/types/supabase';
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
+import { MouseEvent } from 'react';
 
 export const useDataHandler = () => {
   const storeId = useAuthState(state => state.storeId);
@@ -32,6 +33,7 @@ export const useDataHandler = () => {
         dateType: 'day',
       });
     }
+
     setCalendarCurrentDate(day);
     setSelectedDate(day);
   };
@@ -46,9 +48,19 @@ export const useDataHandler = () => {
    * @param day 날짜가 들어오면 그 날짜 기준으로 1주일치 매출을 가져옵니다.
    * @returns salesStore의 state값 변경으로 void 입니다.
    */
-  const clickShowDataOfDateHandler = (day: Dayjs) => async () => {
-    const { sales, dateType, formatType } = await getDaySales(day.hour(0).subtract(9, 'hour'), storeId!);
-    handleSalesData(sales, dateType, formatType!, day);
+  const clickShowDataOfDateHandler = async (event: MouseEvent<HTMLDivElement>) => {
+    const targetDiv = (event.target as Element).closest('div');
+    if (targetDiv) {
+      const spanElement = targetDiv.querySelector('span');
+      if (spanElement) {
+        // dayjs에 Number로 바꿔서 인자값으로 들어가야 정확한 날짜가 나옵니다.
+        const day = dayjs(Number(spanElement.dataset.dayjs));
+        if (day.isAfter(today, 'day')) return;
+        const { sales, dateType, formatType } = await getDaySales(day.hour(0).subtract(9, 'hour'), storeId!);
+        handleSalesData(sales, dateType, formatType!, day);
+      }
+    }
+
     setIsShow(false);
   };
 

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -13,6 +13,7 @@ interface CalendarType {
 interface CalendarCellType {
   mode: CalendarModeType;
   page: CalendarPageType;
+  clickShowDataOfDateHandler?: (e: MouseEvent<HTMLDivElement>) => Promise<void>;
 }
 
 /**
@@ -24,7 +25,6 @@ interface CellItemProps {
   day: Dayjs;
   salesData?: CalendarDataType;
   getMinMaxSalesType?: (param: CalendarDataType) => GetMinMaxSalesReturnType;
-  clickShowDataOfDateHandler?: (day: Dayjs) => () => Promise<void>;
   holiday: HolidayType[];
   mode: CalendarModeType;
   page: CalendarPageType;


### PR DESCRIPTION
이벤트 버블링 활용하여  Calendar Component 단에서 hook으로 click 이벤트 함수 호출 한번 만 해주고 props로 조건부로 내려주면서  CellItem Component를 감싸는 부모 컴포넌트인 Cell컴포넌트에 click이벤트로 내려주어 

cellItem 컴포넌트에 data-dayjs ={day : Dayjs} 를 가지고 비동기 통신 하게 하여 click 이벤트 함수 호출 최소 30번에서 한번의 호출로  해결하였습니다.